### PR TITLE
Hotfix/0.5.0.2

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Tested up to: 6.0.2
 Requires PHP: 7.4
 Requires Posts To Posts: 1.6.6
 Requires WPGraphQL: 1.8.1
-Stable tag: 0.5.0.1
+Stable tag: 0.5.0.2
 Maintained at: https://github.com/harness-software/wp-graphql-posts-to-posts
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html

--- a/src/Mutations/AbstractMutation.php
+++ b/src/Mutations/AbstractMutation.php
@@ -10,7 +10,7 @@ use WPGraphQLPostsToPosts\Interfaces\Hookable;
 abstract class AbstractMutation implements Hookable {
 
 	public function register_hooks() : void {
-		add_action( 'graphql_register_types_late', [ $this, 'register_input_fields' ] );
+		add_action( 'graphql_register_types', [ $this, 'register_input_fields' ] );
 	}
 
 	abstract public function register_input_fields() : void;

--- a/src/Mutations/PostMutation.php
+++ b/src/Mutations/PostMutation.php
@@ -16,8 +16,15 @@ class PostMutation extends AbstractMutation {
 	public function register_input_fields(): void {
 		$post_types = WPGraphQL::get_allowed_post_types( 'objects' );
 
+		$types_wtith_connections = Fields::get_post_types_with_connections();
+
 		foreach ( $post_types as $post_type ) {
-			$graphql_single_name = $post_type->graphql_single_name;
+			// Bail if no P2P connection registered for type.
+			if ( ! in_array( $post_type->name, $types_wtith_connections, true ) ) {
+				continue;
+			}
+
+			$graphql_single_name = ucfirst( $post_type->graphql_single_name );
 
 			register_graphql_field(
 				'Update' . $graphql_single_name . 'Input',

--- a/src/Types/Fields.php
+++ b/src/Types/Fields.php
@@ -34,6 +34,19 @@ class Fields implements Hookable {
 		return array_filter( self::$p2p_connections, [ __CLASS__, 'should_create_connection' ] );
 	}
 
+	public static function get_post_types_with_connections() : array {
+		$connections = self::$p2p_connections;
+
+		$post_types = [];
+
+		foreach ( $connections as $name => $args ) {
+			$post_types[] = $args['from'];
+			$post_types[] = $args['to'];
+		}
+
+		return array_unique( $post_types );
+	}
+
 	public static function should_create_connection( array $connection ) : bool {
 		return self::should_connect_object( $connection['from'] )
 			&& self::should_connect_object( $connection['to'] );

--- a/src/Types/Post.php
+++ b/src/Types/Post.php
@@ -16,8 +16,15 @@ class Post implements Hookable {
 	public function register_where_input_fields() : void {
 		$post_types = WPGraphQL::get_allowed_post_types( 'objects' );
 
+		$types_wtith_connections = Fields::get_post_types_with_connections();
+
 		foreach ( $post_types as $post_type ) {
-			$graphql_single_name = $post_type->graphql_single_name;
+			// Bail if no P2P connection registered for type.
+			if ( ! in_array( $post_type->name, $types_wtith_connections, true ) ) {
+				continue;
+			}
+
+			$graphql_single_name = ucfirst( $post_type->graphql_single_name );
 
 			register_graphql_field(
 				'RootQueryTo' . $graphql_single_name . 'ConnectionWhereArgs',

--- a/src/Types/User.php
+++ b/src/Types/User.php
@@ -8,7 +8,7 @@ use WPGraphQL;
 class User implements Hookable {
 
 	public function register_hooks() : void {
-		add_action( 'graphql_register_types_late', [ $this, 'register_where_input_fields' ] );
+		add_action( 'graphql_register_types', [ $this, 'register_where_input_fields' ] );
 		add_filter( 'graphql_map_input_fields_to_wp_user_query', [ $this, 'modify_query_input_fields' ], 10 );
 	}
 

--- a/wp-graphql-posts-to-posts.php
+++ b/wp-graphql-posts-to-posts.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WPGraphQL for Posts 2 Posts
  * Description: Creates WPGraphQL connections for all of your Posts 2 Posts connections.
- * Version:     0.5.0.1
+ * Version:     0.5.0.2
  * Author:      Harness Software, Kellen Mace
  * Author URI:  https://harnessup.com/
  * License:     GPLv2 or later


### PR DESCRIPTION
- fix: replace usage of `graphql_register_types_late` with `graphql_register_types` to ensure inputs are added correctly to the schema.
- fix: ensure inputs are registered only on CPTs that have a p2p connection registered.